### PR TITLE
fix: ignore template for index routes

### DIFF
--- a/lib/rules/require-valid-page-title.js
+++ b/lib/rules/require-valid-page-title.js
@@ -27,7 +27,7 @@ export default class RequireValidPageTitle extends Rule {
             },
             Program: {
                 exit(node) {
-                    if (!this.isPageTitleFound && isFile(node.loc)) {
+                    if (!this.isPageTitleFound && isFile(node.loc) && !this.filePath.endsWith('index.hbs')) {
                         this.log({
                             message: 'Missing page title',
                             node,


### PR DESCRIPTION
Did this because mostly we'll not be needing a page-title for index routes.